### PR TITLE
Update readme todo list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ $('a').track({ prefix: 'ga-' });
 - [x] Add umd during build process
 - [x] Add individual data attributes
 - [x] Add `transport: 'beacon'` support. https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms
-- [ ] Add ability for elements created after pageload to trigger events.
+- [ ] Store each instance of the plugin as a dataset item, to help prevent re-initializing items.
 - [ ] Handle multiple event types, i.e. `data-event-type="load click"`
 - [ ] Possibly refactor to handle all hit types, i.e. page/app tracking (`pageview`, `screenview`), ecommerce tracking (`transaction` or `item`)


### PR DESCRIPTION
Remove `- [ ] Add ability for elements created after pageload to trigger events.` from readme todo list.

While it sounds great, it's not practical for a jquery plugin like this that needs to know the event types in advance in order to know what to listen for. If those event types, by design, are ascertained by looking at the `data` attributes of an element, it's kind of impossible to delegate events _before_ an element exists in the DOM.

Instead, the proper workflow here would be to re-initialize jquery track when any new elements are injected into the document. i.e. 

```js
$.get('/some/api/url', function (data) {
  // use data to render something in the DOM
  $('<selector to target new DOM elements>').track();
});
```